### PR TITLE
Add parameter to deploy to site root

### DIFF
--- a/src/Nuget/Package.nuspec
+++ b/src/Nuget/Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>PackageWeb</id>
-    <version>1.1.16.3</version>
+    <version>1.1.17</version>
     <authors>Sayed Ibrahim Hashimi</authors>
     <owners>Sayed Ibrahim Hashimi</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/src/Publish-Interactive.ps1
+++ b/src/Publish-Interactive.ps1
@@ -507,6 +507,7 @@ function PromptUserForParameterValues {
     if(!($publishParameters)) { $publishParameters = @() }
     
 	$publishParameters += @{name="Computer name";defaultValue="localhost";isInternalParameter=$true}
+	$publishParameters += @{name="Deploy to site root";defaultValue="false";isInternalParameter=$true}
     $publishParameters += @{name="Username";defaultValue="";isInternalParameter=$true}
     $publishParameters += @{name="Password";defaultValue="";isInternalParameter=$true;isSecure=$true}
     $publishParameters += @{name=("{0}" -f $paramNameAllowUntrusted);defaultValue="false";isInternalParameter=$true}
@@ -626,9 +627,15 @@ function BuildMSDeployCommand {
     $isCompNameLocalhost = IsComputerNameLocalhost -compName $compNameParamValue
     if($compNameParamValue.length -gt 0 -and !$isCompNameLocalhost) {
         # Since this is not for localhost we need to combine site name with this for hoster scenarios
-        $siteNameParam = FindParamByName -allParams $paramValues -name $paramNameIISApp
         $compNameFixedUp = FixupMSDeployServiceUrl -msdServiceUrl $compNameParamValue
-        $compNameCommandFrag = ",ComputerName='{0}?site={1}'" -f $compNameFixedUp, $siteNameParam.Value
+		$deployToSiteRoot = [system.convert]::ToBoolean((FindParamByName -allParams $paramValues -name "Deploy to site root").Value)
+		if ($deployToSiteRoot) {
+			$compNameCommandFrag = ",ComputerName='{0}'" -f $compNameFixedUp
+		}
+        else {
+		    $siteNameParam = FindParamByName -allParams $paramValues -name $paramNameIISApp
+			$compNameCommandFrag = ",ComputerName='{0}?site={1}'" -f $compNameFixedUp, $siteNameParam.Value
+		}
     }
 
     # Auth type parameter


### PR DESCRIPTION
We found that we couldn't use package-web to deploy some of our projects as they were root of the web application. I added a parameter that switches deployment to the site root. The default value is false for backwards compatibility. Please let me know if any additional work is needed to get this pulled in.

Thanks!

Rob Ribeiro
