### PR TITLE
Split the transforms on a '|' and ';'. Fixes #73

### DIFF
--- a/src/Publish-Interactive.ps1
+++ b/src/Publish-Interactive.ps1
@@ -288,7 +288,7 @@ function ExecuteTransforms(){
 		
         $transforms = @()
         if($transformName){
-            $transforms = $transformName.Split(';')
+            $transforms = $transformName -split '[;|]' #support splitting on both ';' and '|'
         }
 
         ExecuteWebConfigTransforms -deployFolder $deployFolder -transformsToExecute $transforms | Out-Null


### PR DESCRIPTION
This would allow the call to the ps file to have `;TransformName=Release|SomeOtherTransform` rather than `;TransformName=Release;SomeOtherTransform`.
